### PR TITLE
修复没有请求体时init_body报错

### DIFF
--- a/lib/resty/upload_rate_limit.lua
+++ b/lib/resty/upload_rate_limit.lua
@@ -13,7 +13,11 @@ local mt = {
 
 local function limit_upload_rate(rate, after, buf_size, chunk_size)
     if rate then
-        local sock = req_socket()
+        local sock,err = req_socket()
+        if ( err == "no body" ) then
+            ngx.log(ngx.ERR,err)
+            return
+        end
         local start = ngx_now()
 
         local rate_in_bytes = rate * 1024


### PR DESCRIPTION
没有请求体的请求init_body会报错